### PR TITLE
chore: replace CLAHub to CLA assistant

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,1 +1,1 @@
-To get started, <a href="https://www.clahub.com/agreements/vivliostyle/vivliostyle-print">sign the Contributor License Agreement</a>.
+To get started, <a href="https://cla-assistant.io/vivliostyle/">sign the Contributor License Agreement</a>.


### PR DESCRIPTION
Since [CLAHub is down](https://github.com/clahub/clahub/issues/174), we need to switch to an alternative.
So, let's use [CLA assistant](https://cla-assistant.io/).