### PR TITLE
sync version with core 2.1.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@vivliostyle/print",
-    "version": "2.0.0",
+    "version": "2.1.4",
     "description": "Allows page-layouting using the vivliostyle for printing within a website without destroying the original layout",
     "main": "dist/index.cjs.js",
     "jsnext:main": "dist/index.es6.js",
@@ -36,7 +36,7 @@
     "homepage": "https://github.com/vivliostyle/vivliostyle-print#readme",
     "devDependencies": {
         "@babel/core": "^7.9.0",
-        "@vivliostyle/core": "^2.0.0",
+        "@vivliostyle/core": "^2.1.4",
         "eslint": "^6.8.0",
         "gh-pages": "^2.2.0",
         "rollup": "^2.3.2",


### PR DESCRIPTION
The current [`@vivliostyle/core`](https://www.npmjs.com/package/@vivliostyle/core) version is 2.1.4 but [`@vivliostyle/print`](https://www.npmjs.com/package/@vivliostyle/print) has not been updated since 2.0.0.

I think we should sync the vivliostyle/print version with the vivliostyle/core version and do `npm publish` each time vivliostyle/core is updated.

@johanneswilm Please test vivliostyle/print with core v2.1.4 and merge this and npm publish if no problem found.


