### PR TITLE
Add errorCallback to demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ const htmlDoc = `<!doctype html>
     config = {
         title: 'my printed page',
         printCallback: iframeWin => iframeWin.print() // optional: only needed if calling something other than window.print() for printing.
+        errorCallback: message => alert(message) // optional: only needed if you want to handle errors.
     }
 
 printHTML(htmlDoc, config)

--- a/demo/index.js
+++ b/demo/index.js
@@ -21,11 +21,15 @@ document.getElementById('print').addEventListener('click', () => {
             const pageCount = iframeWin.document.querySelectorAll('[data-vivliostyle-page-container]').length
             console.log(`page count: ${pageCount}`)
             iframeWin.print()
+        },
+        errorCallback = message => {
+            alert(message)
         }
 
     printHTML(htmlDoc, {
         title,
         printCallback,
+        errorCallback,
         hideIframe: true, // Whether to use a hidden iframe (default: true)
         removeIframe: true // Whether to remove the iframe after use (default: true)
     })


### PR DESCRIPTION
This PR adds `errorCallback` to the printHTML() config options to handle errors in the vivliostyle-print demo.

About the `errorCallback`, see:

- https://github.com/vivliostyle/vivliostyle.js/pull/1287
